### PR TITLE
Update release action to support hierarchical tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Create release
 on:
   push:
     tags:
-    - '*'
+    - '**'
 
 jobs:
   build:


### PR DESCRIPTION
This PR updates `release` workflow to support [hierarchical](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet) tags. Because of this, the release workflow was not being triggered.
<img width="748" alt="Screen Shot 2022-07-12 at 14 29 54" src="https://user-images.githubusercontent.com/10829612/178501597-9d3a5caa-5434-46c7-b318-b9da96b9acf6.png">

