### PR TITLE
Add useEventListener hook

### DIFF
--- a/packages/hooks/src/use-event-listener/index.test.ts
+++ b/packages/hooks/src/use-event-listener/index.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Module dependencies.
+ */
+
+import { fireEvent } from '@testing-library/react';
+import { renderHook } from '@testing-library/react-hooks/dom';
+import { useEventListener } from './';
+
+/**
+ * Mocked constants.
+ */
+
+const eventName = 'click';
+const handler = jest.fn();
+const ref = { current: document.createElement('div') };
+
+/**
+ * Test `useEventListener` hook.
+ */
+
+describe(`'useEventListener' hook`, () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should bind/unbind the event listener to the window when element is not provided', () => {
+    const addEventListenerSpy = jest.spyOn(window, 'addEventListener');
+    const removeEventListenerSpy = jest.spyOn(window, 'removeEventListener');
+
+    const { unmount } = renderHook(() => useEventListener(eventName, handler));
+
+    expect(addEventListenerSpy).toHaveBeenCalledWith(
+      eventName,
+      expect.any(Function),
+      undefined
+    );
+
+    unmount();
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      eventName,
+      expect.any(Function)
+    );
+  });
+
+  it('should bind/unbind the event listener to the element when element is provided', () => {
+    const mockedAddEventListenerSpy = jest.spyOn(
+      ref.current,
+      'addEventListener'
+    );
+
+    const mockedRemoveEventListenerSpy = jest.spyOn(
+      ref.current,
+      'removeEventListener'
+    );
+
+    const { unmount } = renderHook(() =>
+      useEventListener(eventName, handler, ref)
+    );
+
+    expect(mockedAddEventListenerSpy).toHaveBeenCalledTimes(1);
+    expect(mockedAddEventListenerSpy).toHaveBeenCalledWith(
+      eventName,
+      expect.any(Function),
+      undefined
+    );
+
+    unmount();
+
+    expect(mockedRemoveEventListenerSpy).toHaveBeenCalledWith(
+      eventName,
+      expect.any(Function)
+    );
+  });
+
+  it('should bind/unbind the event listener to the document when document is provided', () => {
+    const docRef = { current: window.document };
+    const addEventListenerSpy = jest.spyOn(docRef.current, 'addEventListener');
+    const removeEventListenerSpy = jest.spyOn(
+      docRef.current,
+      'removeEventListener'
+    );
+
+    const { unmount } = renderHook(() =>
+      useEventListener(eventName, handler, docRef)
+    );
+
+    expect(addEventListenerSpy).toHaveBeenCalledTimes(1);
+    expect(addEventListenerSpy).toHaveBeenCalledWith(
+      eventName,
+      expect.any(Function),
+      undefined
+    );
+
+    unmount();
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      eventName,
+      expect.any(Function)
+    );
+  });
+
+  it('should pass the options to the event listener', () => {
+    const addEventListenerSpy = jest.spyOn(window, 'addEventListener');
+    const options = {
+      capture: true,
+      once: true,
+      passive: true
+    };
+
+    renderHook(() => useEventListener(eventName, handler, undefined, options));
+
+    expect(addEventListenerSpy).toHaveBeenCalledWith(
+      eventName,
+      expect.any(Function),
+      options
+    );
+  });
+
+  it('should call the event listener handler when the event is triggered', () => {
+    renderHook(() => useEventListener('click', handler, ref));
+
+    fireEvent.click(ref.current);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('should have the correct event type', () => {
+    const clickHandler = jest.fn();
+    const keydownHandler = jest.fn();
+
+    renderHook(() => useEventListener('click', clickHandler, ref));
+    renderHook(() => useEventListener('keydown', keydownHandler, ref));
+
+    fireEvent.click(ref.current);
+    fireEvent.keyDown(ref.current);
+
+    expect(clickHandler).toHaveBeenCalledWith(expect.any(MouseEvent));
+    expect(keydownHandler).toHaveBeenCalledWith(expect.any(KeyboardEvent));
+  });
+});

--- a/packages/hooks/src/use-event-listener/index.ts
+++ b/packages/hooks/src/use-event-listener/index.ts
@@ -1,0 +1,51 @@
+/**
+ * Module dependencies.
+ */
+
+import { RefObject, useEffect } from 'react';
+
+/**
+ * `EventName` type.
+ */
+
+type EventName =
+  | keyof DocumentEventMap
+  | keyof HTMLElementEventMap
+  | keyof WindowEventMap;
+
+/**
+ * `Handler` type.
+ */
+
+type Handler =
+  | ((event: DocumentEventMap[keyof DocumentEventMap]) => void)
+  | ((event: HTMLElementEventMap[keyof HTMLElementEventMap]) => void)
+  | ((event: WindowEventMap[keyof WindowEventMap]) => void)
+  | ((event: Event) => void);
+
+/**
+ * `Element` type.
+ */
+
+type Element = RefObject<Document | HTMLElement> | null | undefined;
+
+/**
+ * Export `useEventListener` hook.
+ */
+
+export function useEventListener(
+  eventName: EventName,
+  handler: Handler,
+  element?: Element,
+  options?: boolean | AddEventListenerOptions
+): void {
+  useEffect(() => {
+    const targetElement = element?.current ?? window;
+
+    if (!targetElement) return;
+
+    targetElement.addEventListener(eventName, handler, options);
+
+    return () => targetElement.removeEventListener(eventName, handler);
+  }, [element, eventName, handler, options]);
+}


### PR DESCRIPTION
This PR adds `useEventListener` hook.
~Blocked by #3~ 

### Usage
```tsx
const ref = useRef<HTMLDivElement>();
const onWindowResize = () => console.log('window resized!');  
const onScroll = (event: Event) => console.log(event);
  
// no element passed defaults to `window`
useEventListener('resize', onWindowResize); 
  
useEventListener('scroll', onScroll, ref);
```