### PR TITLE
Add useBreakpoint hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ yarn add @untile/react-core
 
 ## Documentation
 
-- [React components](docs/components/README.md)
-- [React hooks](docs/hooks/README.md)
-- [Styles](docs/styles/README.md)
-- [utils](docs/utils/README.md)
+- [React components 📦](docs/components/README.md)
+- [React hooks 🪝](docs/hooks/README.md)
+- [Styles ✨](docs/styles/README.md)
+- [Utils 🛠️](docs/utils/README.md)
 
 ## Project setup
 

--- a/docs/components/README.md
+++ b/docs/components/README.md
@@ -1,53 +1,56 @@
 # React Components
 
-A collection of [Untile](https://github.com/untile) react components to build 
+A collection of [Untile](https://github.com/untile) react components to build
 web applications based on react.
 
+<details>
+  <summary><h3>RawHtml</h3></summary>
 
-### `RawHtml`
+  #### Type
 
-#### Type
+  ```tsx
+  interface RawHtmlProps {
+    children: ReactNode;
+    className?: string;
+    element?: string;
+  }
+  ```
 
-```tsx
-interface RawHtmlProps {
-  children: ReactNode;
-  className?: string;
-  element?: string;
-}
-```
+  #### Usage
 
-#### Usage
+  ```jsx
+  import { RawHtml } from '@untile/react-core/components/raw-html';
 
-```jsx
-import { RawHtml } from '@untile/react-core/components/raw-html';
+  <RawHtml element={'div'}>
+    {`foo<br>bar`}
+  </RawHtml>
+  ```
+</details>
 
-<RawHtml element={'div'}>
-  {`foo<br>bar`}
-</RawHtml>
-```
+<details>
+  <summary><h3>Svg</h3></summary>
 
-### `Svg`
+  #### Type
 
-#### Type
+  ```tsx
+  interface SvgProps {
+    className?: string;
+    color?: string;
+    icon: string;
+    size: string | unknown;
+  }
+  ```
 
-```tsx
-interface SvgProps {
-  className?: string;
-  color?: string;
-  icon: string;
-  size: string | unknown;
-}
-```
+  #### Usage
 
-#### Usage
+  ```jsx
+  import { Svg } from '@untile/react-core/components/svg';
+  import svgIcon from './foo/bar.svg';
 
-```jsx
-import { Svg } from '@untile/react-core/components/svg';
-import svgIcon from './foo/bar.svg';
-
-<Svg
-  color={'red'}
-  icon={svgIcon}
-  size={'20px'}
-/>
-```
+  <Svg
+    color={'red'}
+    icon={svgIcon}
+    size={'20px'}
+  />
+  ```
+</details>

--- a/docs/hooks/README.md
+++ b/docs/hooks/README.md
@@ -1,119 +1,164 @@
 # React Hooks
 
-A collection of [Untile](https://github.com/untile) react hooks to build web 
+A collection of [Untile](https://github.com/untile) react hooks to build web
 applications.
 
 ## Hooks
 
-### `useBodyScroll`
+<details>
+  <summary><h3>useBodyScroll</h3></summary>
 
-This hook updates the body overflow style.
+  This hook updates the body overflow style.
 
-#### Type
+  #### Type
 
-```tsx
-useBodyScroll({ off: boolean }): void
-```
+  ```tsx
+  useBodyScroll({ off: boolean }): void
+  ```
 
-#### Usage
+  #### Usage
 
-```jsx
-import { useBodyScroll } from '@untile/react-core/hooks/use-body-scroll';
+  ```jsx
+  import { useBodyScroll } from '@untile/react-core/hooks/use-body-scroll';
 
-useBodyScroll({ off: true }); // <body style="overflow:hidden;">
-useBodyScroll({ off: false }); // <body style="">
-```
+  useBodyScroll({ off: true }); // <body style="overflow:hidden;">
+  useBodyScroll({ off: false }); // <body style="">
+  ```
+</details>
 
-### `useEventListener`
+<details>
+  <summary><h3>useBreakpoint</h3></summary>
 
-#### Type
+  This hook leverages the use of the breakpoints to return the media-query result.
 
-```tsx
-useEventListener(
-  eventName: EventName,
-  handler: Handler,
-  element?: Element,
-  options?: boolean | AddEventListenerOptions
-): void
-```
+  #### Type
 
-#### Usage
+  ```tsx
+  type Value = Breakpoint | number;
 
-```jsx
-import { useEventListener } from '@untile/react-core/hooks/use-event-listener';
+  useBreakpoint(min: Value, max?: Value): boolean
+  ```
 
-const ref = useRef<HTMLDivElement>();
-const onWindowResize = () => console.log('window resized!');  
-const onScroll = (event: Event) => console.log(event);
-  
-useEventListener('resize', onWindowResize); // no element passed defaults to `window`
-  
-useEventListener('scroll', onScroll, ref);
-```
+  #### Usage
 
-### `useMediaQuery`
+  ```jsx
+  import { useBreakpoint } from '@untile/react-core/hooks/use-breakpoint';
 
-This hook checks if some media query matches with the window width.
+  const isPhoneX = useBreakpoint(0, 375); // Viewports lower than `375px`.
+  const isTablet = useBreakpoint('ms', 1023); // Viewports between `ms` and `1023px`.
+  const isLargeTablet = useBreakpoint(1024, 'lg'); // Viewports between `1024px` and `lg`.
+  const isDesktop = useBreakpoint('md'); // Viewports greater than `md`.
+  ```
+</details>
 
-#### Type
+<details>
+  <summary><h3>useEventListener</h3></summary>
+  It leverages the Event listener setup.
 
-```tsx
-useMediaQuery(query: string): boolean
-```
+  #### Type
 
-#### Usage
+  ```tsx
+  useEventListener(
+    eventName: EventName,
+    handler: Handler,
+    element?: Element,
+    options?: boolean | AddEventListenerOptions
+  ): void
+  ```
 
-```jsx
-import { useMediaQuery } from '@untile/react-core/hooks/use-media-query';
+  #### Usage
 
-const matches = useMediaQuery('(min-width: 480px)'); // true/false
-```
+  ```jsx
+  import { useEventListener } from '@untile/react-core/hooks/use-event-listener';
 
-### `usePrevious`
+  const ref = useRef<HTMLDivElement>();
+  const onWindowResize = () => console.log('window resized!');
+  const onScroll = (event: Event) => console.log(event);
 
-#### Type
+  useEventListener('resize', onWindowResize); // no element passed defaults to `window`
 
-```tsx
-usePrevious<T = any>(value: T): T | undefined
-```
+  useEventListener('scroll', onScroll, ref);
+  ```
+</details>
 
-#### Usage
+<details>
+  <summary><h3>useMediaQuery</h3></summary>
 
-```jsx
-import { usePrevious } from '@untile/react-core/hooks/use-previous';
+  This hook checks if some media query matches with the window width.
 
-const [state, setState] = useState('initial');
-const previousState = usePrevious(state);
-```
+  #### Type
 
-### `useStepper`
+  ```tsx
+  useMediaQuery(query: string): boolean
+  ```
 
-#### Type
+  #### Usage
 
-```tsx
-useStepper<T = string>(props: StepperProps<T>): StepperResult<T>
-```
+  ```jsx
+  import { useMediaQuery } from '@untile/react-core/hooks/use-media-query';
 
-#### Usage
+  const matches = useMediaQuery('(min-width: 480px)'); // true/false
+  ```
+</details>
 
-```jsx
-import { useStepper } from '@untile/react-core/hooks/use-stepper';
+<details>
+  <summary><h3>usePrevious</h3></summary>
 
-useStepper({ steps: [1, 2 , 3] })
-```
+  Uses a reference for a previous value so it can be used in sync with the previous React state updates.
 
-### `useToggle`
+  #### Type
 
-#### Type
+  ```tsx
+  usePrevious<T = any>(value: T): T | undefined
+  ```
 
-```tsx
-useToggle(initialState = false): [boolean, () => void]
-```
+  #### Usage
 
-#### Usage
+  ```jsx
+  import { usePrevious } from '@untile/react-core/hooks/use-previous';
 
-```jsx
-import { useToggle } from '@untile/react-core/hooks/use-toggle';
+  const [state, setState] = useState('initial');
+  const previousState = usePrevious(state);
+  ```
+</details>
 
-const [state, toggle] = useToggle();
-```
+
+<details>
+  <summary><h3>useStepper</h3></summary>
+
+  Provides a way to use step by step like in a wizard.
+
+  #### Type
+
+  ```tsx
+  useStepper<T = string>(props: StepperProps<T>): StepperResult<T>
+  ```
+
+  #### Usage
+
+  ```jsx
+  import { useStepper } from '@untile/react-core/hooks/use-stepper';
+
+  useStepper({ steps: [1, 2 , 3] })
+  ```
+</details>
+
+<details>
+  <summary><h3>useToggle</h3></summary>
+
+  State that toggles between boolean states.
+
+  #### Type
+
+  ```tsx
+  useToggle(initialState = false): [boolean, () => void]
+  ```
+
+  #### Usage
+
+  ```jsx
+  import { useToggle } from '@untile/react-core/hooks/use-toggle';
+
+  const [state, toggle] = useToggle();
+  ```
+</details>

--- a/docs/styles/README.md
+++ b/docs/styles/README.md
@@ -1,72 +1,78 @@
 # React Styles
 
-A collection of [Untile](https://github.com/untile) react styles utils to build 
+A collection of [Untile](https://github.com/untile) react styles utils to build
 web applications based on react.
 
 ## Styles
 
-### `breakpoints`
+<details>
+  <summary><h3>breakpoints</h3></summary>
 
-Breakpoints configuration object.
+  Breakpoints configuration object.
 
-#### Usage
+  #### Usage
 
-```jsx
-import { breakpoints } from '@untile/react-core/styles/breakpoints';
-```
+  ```jsx
+  import { breakpoints } from '@untile/react-core/styles/breakpoints';
+  ```
 
-### `Global`
+  ### `Global`
 
-`Global` is a component with global styles. Normalize is a css-normalize content 
-to interpolate into styled component.
+  `Global` is a component with global styles. Normalize is a css-normalize content
+  to interpolate into styled component.
 
-#### Usage
+  #### Usage
 
-```jsx
-import { Global } from '@untile/react-core/styles/global';
+  ```jsx
+  import { Global } from '@untile/react-core/styles/global';
 
-return (
-  <Global />
-);
-```
+  return (
+    <Global />
+  );
+  ```
+</details>
 
-### `media`
+<details>
+  <summary><h3>media</h3></summary>
 
-`media` is a style util used to create and interpolate media queries inside a 
-styled-component. Breakpoints are based on **breakpoints configuration object**.
+  `media` is a style util used to create and interpolate media queries inside a
+  styled-component. Breakpoints are based on **breakpoints configuration object**.
 
-#### Usage
+  #### Usage
 
-```jsx
-import { media } from '@untile/react-core/styles/media';
+  ```jsx
+  import { media } from '@untile/react-core/styles/media';
 
-const Foo = styled.div`
-  ${media.min.xs`
-    color: red;
-  `}
+  const Foo = styled.div`
+    ${media.min.xs`
+      color: red;
+    `}
 
-  ${media.max.sm`
-    background-color: green;
-  `}
-`;
-```
+    ${media.max.sm`
+      background-color: green;
+    `}
+  `;
+  ```
+</details>
 
-### `svgBackground`
+<details>
+  <summary><h3>svgBackground</h3></summary>
 
-`svgBackground` is a style util used to create an inline svg as a style.
+  `svgBackground` is a style util used to create an inline svg as a style.
 
-#### Type
+  #### Type
 
-```jsx
-svgBackground(string): TemplateStringsArray
-```
+  ```jsx
+  svgBackground(string): TemplateStringsArray
+  ```
 
-#### Usage
+  #### Usage
 
-```jsx
-import { svgBackground } from '@untile/react-core/styles/svg-background';
+  ```jsx
+  import { svgBackground } from '@untile/react-core/styles/svg-background';
 
-const Foo = styled.div`
-  ${svgBackground('<svg viewBox="0 0 20 20"><circle cx="60" cy="60" r="50"/></svg>')}
-`;
-```
+  const Foo = styled.div`
+    ${svgBackground('<svg viewBox="0 0 20 20"><circle cx="60" cy="60" r="50"/></svg>')}
+  `;
+  ```
+</details>

--- a/docs/utils/README.md
+++ b/docs/utils/README.md
@@ -1,25 +1,27 @@
 # React utils
 
-A collection of [Untile](https://github.com/untile) utilities to build web 
+A collection of [Untile](https://github.com/untile) utilities to build web
 applications based on typescript.
 
 ## Utils
 
-### `isExternalUrl`
+<details>
+  <summary><h3>isExternalUrl</h3></summary>
 
-This function checks if the string path is an external url.
+  This function checks if the string path is an external url.
 
-#### Type
+  #### Type
 
-```tsx
-isExternalUrl(url: string): boolean
-```
+  ```tsx
+  isExternalUrl(url: string): boolean
+  ```
 
-#### Usage
+  #### Usage
 
-```jsx
-import { isExternalUrl } from '@untile/react-core/utils/is-external-url';
+  ```jsx
+  import { isExternalUrl } from '@untile/react-core/utils/is-external-url';
 
-isExternalUrl('http://foo.bar'); // true
-isExternalUrl('/foo/bar'); // false
-```
+  isExternalUrl('http://foo.bar'); // true
+  isExternalUrl('/foo/bar'); // false
+  ```
+</details>

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,6 +5,9 @@
  */
 
 module.exports = {
+  moduleNameMapper: {
+    '^src/(.*)$': '<rootDir>/src/$1'
+  },
   preset: 'ts-jest',
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
   testEnvironment: 'jsdom',

--- a/src/hooks/use-breakpoint/index.test.ts
+++ b/src/hooks/use-breakpoint/index.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Module dependencies.
+ */
+
+import { renderHook } from '@testing-library/react-hooks/dom';
+import { useBreakpoint } from './';
+
+/**
+ * Mock match.
+ */
+
+function mockMatch(matches: boolean) {
+  Object.defineProperty(window, 'matchMedia', {
+    value: jest.fn().mockImplementation(query => ({
+      addEventListener: jest.fn(),
+      addListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+      matches,
+      media: query,
+      onchange: null,
+      removeEventListener: jest.fn(),
+      removeListener: jest.fn()
+    })),
+    writable: true
+  });
+}
+
+/**
+ * Test `useBreakpoint` hook.
+ */
+
+describe(`'useBreakpoint' hook`, () => {
+  beforeAll(() => {
+    window.innerWidth = 1300;
+    window.dispatchEvent(new Event('resize'));
+  });
+
+  it('should return `true` if window width is within `lg` and `xl`', () => {
+    mockMatch(true);
+
+    const { result } = renderHook(() => useBreakpoint('lg', 'xl'));
+
+    expect(result.current).toBe(true);
+  });
+
+  it('should return `false` if window width is lower than `800px`', () => {
+    mockMatch(false);
+
+    const { result } = renderHook(() => useBreakpoint(0, 800));
+
+    expect(result.current).toBe(false);
+  });
+});

--- a/src/hooks/use-breakpoint/index.ts
+++ b/src/hooks/use-breakpoint/index.ts
@@ -1,0 +1,34 @@
+/**
+ * Module dependencies.
+ */
+
+import { Breakpoint, breakpoints } from 'src/styles/breakpoints';
+import { useMediaQuery } from 'src/hooks/use-media-query';
+import { useMemo } from 'react';
+
+/**
+ * `Value` type.
+ */
+
+type Value = Breakpoint | number;
+
+/**
+ * Export `useBreakpoint` hook.
+ */
+
+export function useBreakpoint(min: Value, max?: Value): boolean {
+  const query = useMemo(() => {
+    const minValue =
+      typeof min === 'number' ? min : breakpoints[min as Breakpoint];
+
+    const maxValue =
+      typeof max === 'number' ? max : breakpoints[max as Breakpoint];
+
+    const minQuery = `(min-width: ${minValue}px)`;
+    const maxQuery = maxValue ? ` and (max-width: ${maxValue}px)` : '';
+
+    return `${minQuery}${maxQuery}`;
+  }, [max, min]);
+
+  return useMediaQuery(query);
+}

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "esModuleInterop": true,
     "jsx": "react",
-    "module": "commonjs"
+    "module": "commonjs",
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1053,9 +1053,9 @@
     "@babel/types" "^7.3.0"
 
 "@types/eslint@^8.4.2":
-  version "8.21.3"
-  resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-8.21.3.tgz#5794b3911f0f19e34e3a272c49cbdf48d6f543f2"
-  integrity sha512-fa7GkppZVEByMWGbTtE5MbmXWJTVbrjjaS8K6uQj+XtuuUv1fsuPAxhygfqLmsb/Ufb3CV8deFCpiMfAgi00Sw==
+  version "8.37.0"
+  resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-8.37.0.tgz#29cebc6c2a3ac7fea7113207bf5a828fdf4d7ef1"
+  integrity sha512-Piet7dG2JBuDIfohBngQ3rCt7MgO9xCO4xIMKxBThCq5PNRB91IjlJ10eJVwfoNtvTErmxLzwBZ7rHZtbOMmFQ==
   dependencies:
     "@types/estree" "*"
     "@types/json-schema" "*"
@@ -1861,9 +1861,9 @@ camelize@^1.0.0:
   integrity sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==
 
 caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001449:
-  version "1.0.30001472"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001472.tgz#3f484885f2a2986c019dc416e65d9d62798cdd64"
-  integrity sha512-xWC/0+hHHQgj3/vrKYY0AAzeIUgr7L9wlELIcAvZdDUHlhL/kNxMdnQLOSOQfP8R51ZzPhmHdyMkI0MMpmxCfg==
+  version "1.0.30001473"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001473.tgz#3859898b3cab65fc8905bb923df36ad35058153c"
+  integrity sha512-ewDad7+D2vlyy+E4UJuVfiBsU69IL+8oVmTuZnH5Q6CIUbxNfI50uVpRHbUPDD6SUaN2o0Lh4DhTrvLG/Tn1yg==
 
 chalk@5.2.0:
   version "5.2.0"
@@ -2386,9 +2386,9 @@ eastasianwidth@^0.2.0:
   integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
 
 electron-to-chromium@^1.4.284:
-  version "1.4.342"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.342.tgz#3c7e199c3aa89c993df4b6f5223d6d26988f58e6"
-  integrity sha512-dTei3VResi5bINDENswBxhL+N0Mw5YnfWyTqO75KGsVldurEkhC9+CelJVAse8jycWyP8pv3VSj4BSyP8wTWJA==
+  version "1.4.345"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.345.tgz#c90b7183b39245cddf0e990337469063bfced6f0"
+  integrity sha512-znGhOQK2TUYLICgS25uaM0a7pHy66rSxbre7l762vg9AUoCcJK+Bu+HCPWpjL/U/kK8/Hf+6E0szAUJSyVYb3Q==
 
 emittery@^0.13.1:
   version "0.13.1"


### PR DESCRIPTION
This PR adds a new take on `useBreakpoint` hook in order to make it usable on specific scenarios where we may want to use a different breakpoint that isn't defined on our `breakpoints` config. Its usage is however pretty similar to what we are used to, just that now it receives two slightly different parameters.

~Blocked by #3~

```tsx
type Value = Breakpoint | number;

useBreakpoint(min: Value, max?: Value): boolean
```

### Usage
```tsx
const isPhoneX = useBreakpoints(0, 375); // viewports lower than `375px`
const isTablet = useBreakpoint('ms', 1023); // viewports between `ms` and `1023px`
const isLargeTablet = useBreakpoint(1024, 'lg'); // viewports between `1024px` and `lg`
const isDesktop = useBreakpoint('md'); // viewports greater than `md`
```

⚠️ I'm probably over-engineering this so please fell free to leave your opinion below! 🤔 