### PR TITLE
Add useAutoFocus hook

### DIFF
--- a/packages/hooks/src/use-auto-focus/index.test.tsx
+++ b/packages/hooks/src/use-auto-focus/index.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * Module dependencies.
+ */
+
+import { render } from '@testing-library/react';
+import { useAutoFocus } from './';
+import React, { useRef } from 'react';
+
+/**
+ * `Props` type.
+ */
+
+type Props = {
+  delay?: number;
+  shouldFocus?: boolean;
+};
+
+/**
+ * `Mock` component.
+ */
+
+const Mock = ({ delay, shouldFocus = true }: Props) => {
+  const ref = useRef<HTMLInputElement>(null);
+
+  useAutoFocus(ref, shouldFocus, delay);
+
+  return (
+    <input
+      placeholder={'focus'}
+      ref={ref}
+    />
+  );
+};
+
+/**
+ * Test `useAutoFocus` hook.
+ */
+
+describe(`'useAutoFocus' hook`, () => {
+  it('should focus the element', async () => {
+    const { getByPlaceholderText } = render(<Mock />);
+    const input = getByPlaceholderText('focus');
+
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    expect(document.activeElement === input).toBeTruthy();
+  });
+
+  it('should not focus the element', async () => {
+    const { getByPlaceholderText } = render(<Mock shouldFocus={false} />);
+    const input = getByPlaceholderText('focus');
+
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    expect(document.activeElement !== input).toBeTruthy();
+  });
+
+  it('should focus the element after 500ms', async () => {
+    const { getByPlaceholderText } = render(<Mock delay={500} />);
+    const input = getByPlaceholderText('focus');
+
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    expect(document.activeElement !== input).toBeTruthy();
+
+    await new Promise(resolve => setTimeout(resolve, 400));
+
+    expect(document.activeElement === input).toBeTruthy();
+  });
+
+  it('should not focus the element after 500ms', async () => {
+    const { getByPlaceholderText } = render(<Mock delay={1000} />);
+    const input = getByPlaceholderText('focus');
+
+    await new Promise(resolve => setTimeout(resolve, 500));
+
+    expect(document.activeElement !== input).toBeTruthy();
+  });
+});

--- a/packages/hooks/src/use-auto-focus/index.ts
+++ b/packages/hooks/src/use-auto-focus/index.ts
@@ -1,0 +1,48 @@
+/**
+ * Module dependencies.
+ */
+
+import { RefObject, useEffect } from 'react';
+
+/**
+ * Export `useAutoFocus` hook.
+ */
+
+export function useAutoFocus(
+  ref: RefObject<HTMLElement> | null | undefined,
+  shouldFocus = true,
+  delay?: number,
+  onFocus?: () => void
+): void {
+  useEffect(() => {
+    if (
+      !shouldFocus ||
+      !ref?.current?.focus ||
+      document.activeElement === ref?.current
+    ) {
+      return;
+    }
+
+    const savedRef = ref;
+    const timeout = setTimeout(() => {
+      savedRef?.current?.focus?.();
+
+      const scrollElement = document.scrollingElement as HTMLElement;
+
+      if (scrollElement) {
+        const { scrollLeft, scrollTop } = scrollElement;
+
+        scrollElement.scrollTo(scrollLeft, scrollTop);
+      }
+
+      if (onFocus) {
+        onFocus();
+      }
+    }, delay ?? 0);
+
+    return () => {
+      clearTimeout(timeout);
+      savedRef?.current?.blur?.();
+    };
+  }, [delay, onFocus, ref, shouldFocus]);
+}


### PR DESCRIPTION
This PR adds `useAutoFocus` hook. Also updates `jest` config to also run tests on `.tsx` files.
~Blocked by #3~

### Definition

```tsx
function useAutoFocus(
  ref: RefObject<HTMLElement> | null | undefined,
  shouldFocus = true,
  delay?: number,
  onFocus?: () => void
): void
```

### Usage

```tsx
const inputRef = useRef<HTMLInputElement | null>(null);
const onFocus = () => console.log('input focused!');

<input ref={inputRef} />

useAutoFocus(inputRef);
useAutoFocus(inputRef, false); // won't focus
useAutoFocus(inputRef, true, 1000); // will focus after 1000ms
useAutoFocus(inputRef, true, undefined, onFocus); // will call `onFocus` immediately after
```