### PR TITLE
Add `use-previous` hook

### DIFF
--- a/packages/hooks/src/use-previous/index.test.ts
+++ b/packages/hooks/src/use-previous/index.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Module dependencies.
+ */
+
+import { act, renderHook } from '@testing-library/react-hooks';
+import { usePrevious } from './';
+import { useState } from 'react';
+
+/**
+ * Test `usePrevious` hook.
+ */
+
+describe(`'usePrevious' hook`, () => {
+  it('should match the previous state', () => {
+    const { result } = renderHook(() => {
+      const [state, setState] = useState('initial');
+      const previousState = usePrevious(state);
+
+      return { previousState, setState, state };
+    });
+
+    expect(result.current.previousState).toBe(undefined);
+    expect(result.current.state).toBe('initial');
+
+    act(() => result.current.setState('updated'));
+    expect(result.current.previousState).toBe('initial');
+    expect(result.current.state).toBe('updated');
+
+    act(() => result.current.setState('updatedAgain'));
+    expect(result.current.previousState).toBe('updated');
+    expect(result.current.state).toBe('updatedAgain');
+  });
+});

--- a/packages/hooks/src/use-previous/index.ts
+++ b/packages/hooks/src/use-previous/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Module dependencies.
+ */
+
+import { useEffect, useRef } from 'react';
+
+/**
+ * Export `usePrevious` hook.
+ */
+
+export function usePrevious<T = any>(value: T): T | undefined {
+  const ref = useRef<T>();
+
+  useEffect(() => {
+    ref.current = value;
+  }, [value]);
+
+  return ref.current;
+}


### PR DESCRIPTION
This PRs adds the `use-previous` hook. It keeps track of a state from the previous render
