### PR TITLE
Add `use-stepper` hook

### DIFF
--- a/packages/hooks/src/use-stepper/index.test.ts
+++ b/packages/hooks/src/use-stepper/index.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Module dependencies.
+ */
+
+import { act, renderHook } from '@testing-library/react-hooks';
+import { useStepper } from './';
+
+const getSteps = (maxSteps: number) =>
+  [...Array(maxSteps).keys()].map(index => `step-${index}`);
+
+/**
+ * Stepper hook.
+ */
+
+describe('`useStepper` hook', () => {
+  describe('nextStep', () => {
+    it('should advance to next step', () => {
+      const { result } = renderHook(() => useStepper({ steps: getSteps(5) }));
+
+      expect(result.current.step).toEqual('step-0');
+      expect(result.current.stepIndex).toEqual(0);
+      expect(result.current.lastAction).toEqual('initial');
+      expect(result.current.isLastStep).toEqual(false);
+
+      act(() => {
+        result.current.nextStep();
+      });
+
+      expect(result.current.step).toEqual('step-1');
+      expect(result.current.stepIndex).toEqual(1);
+      expect(result.current.lastAction).toEqual('next');
+      expect(result.current.isLastStep).toEqual(false);
+    });
+
+    it('should stay at the last step', () => {
+      const { result } = renderHook(() => useStepper({ steps: getSteps(2) }));
+
+      act(() => {
+        result.current.nextStep();
+        result.current.nextStep();
+      });
+
+      expect(result.current.step).toEqual('step-1');
+      expect(result.current.stepIndex).toEqual(1);
+      expect(result.current.lastAction).toEqual('next');
+      expect(result.current.isLastStep).toEqual(true);
+    });
+  });
+
+  describe('previousStep', () => {
+    it('should go back to previous step', () => {
+      const { result } = renderHook(() => useStepper({ steps: getSteps(5) }));
+
+      act(() => {
+        result.current.nextStep();
+      });
+
+      expect(result.current.step).toEqual('step-1');
+      expect(result.current.stepIndex).toEqual(1);
+      expect(result.current.lastAction).toEqual('next');
+      expect(result.current.isLastStep).toEqual(false);
+
+      act(() => {
+        result.current.previousStep();
+      });
+
+      expect(result.current.step).toEqual('step-0');
+      expect(result.current.stepIndex).toEqual(0);
+      expect(result.current.lastAction).toEqual('previous');
+      expect(result.current.isLastStep).toEqual(false);
+    });
+
+    it('should stay in the first step', () => {
+      const { result } = renderHook(() => useStepper({ steps: getSteps(5) }));
+
+      act(() => {
+        result.current.previousStep();
+        result.current.previousStep();
+      });
+
+      expect(result.current.step).toEqual('step-0');
+      expect(result.current.stepIndex).toEqual(0);
+      expect(result.current.lastAction).toEqual('previous');
+      expect(result.current.isLastStep).toEqual(false);
+    });
+  });
+
+  describe('goToStep', () => {
+    it('should jump to an arbitrary step', () => {
+      const { result } = renderHook(() => useStepper({ steps: getSteps(5) }));
+
+      act(() => {
+        result.current.goToStep('step-4');
+      });
+
+      expect(result.current.step).toEqual('step-4');
+      expect(result.current.stepIndex).toEqual(4);
+      expect(result.current.lastAction).toEqual('next');
+      expect(result.current.isLastStep).toEqual(true);
+
+      act(() => {
+        result.current.goToStep('step-2');
+      });
+
+      expect(result.current.step).toEqual('step-2');
+      expect(result.current.stepIndex).toEqual(2);
+      expect(result.current.lastAction).toEqual('previous');
+      expect(result.current.isLastStep).toEqual(false);
+    });
+  });
+});

--- a/packages/hooks/src/use-stepper/index.ts
+++ b/packages/hooks/src/use-stepper/index.ts
@@ -1,0 +1,170 @@
+/**
+ * Module dependencies.
+ */
+
+import { useCallback, useReducer } from 'react';
+
+/**
+ * `Steps` type.
+ */
+
+type Steps<T> = Array<T>;
+
+/**
+ * `StepperProps` type.
+ */
+
+type StepperProps<T> = {
+  steps: Steps<T>;
+};
+
+/**
+ * Action types.
+ */
+
+const actionTypes = {
+  goTo: 'goTo',
+  next: 'next',
+  previous: 'previous'
+} as const;
+
+/**
+ * `Action` type.
+ */
+
+type Action = 'initial' | 'next' | 'previous';
+
+/**
+ * `State` type.
+ */
+
+type State<T> = {
+  lastAction: Action;
+  step: T;
+};
+
+/**
+ * Export `StepperResult` type.
+ */
+
+export type StepperResult<T> = State<T> & {
+  goToStep: (step: T) => void;
+  isLastStep: boolean;
+  nextStep: () => void;
+  previousStep: () => void;
+  stepIndex: number;
+};
+
+/**
+ * `ReducerAction` type.
+ */
+
+type ReducerAction<T> =
+  | {
+      payload: null;
+      type: typeof actionTypes.next | typeof actionTypes.previous;
+    }
+  | {
+      payload: State<T>;
+      type: typeof actionTypes.goTo;
+    };
+
+/**
+ * Is last step.
+ */
+
+function isLastStep<T>(steps: Steps<T>, step: T) {
+  return steps.indexOf(step) === steps.length - 1;
+}
+
+/**
+ * Get last action.
+ */
+
+function getLastAction<T>(steps: Steps<T>, currentStep: T, nextStep: T) {
+  if (steps.indexOf(currentStep) > steps.indexOf(nextStep)) {
+    return actionTypes.previous;
+  }
+
+  return actionTypes.next;
+}
+
+/**
+ * Export `useStepper` hook.
+ */
+
+export function useStepper<T = string>(
+  props: StepperProps<T>
+): StepperResult<T> {
+  const { steps } = props;
+  const [{ lastAction, step }, dispatch] = useReducer(
+    (state: State<T>, action: ReducerAction<T>) => {
+      switch (action.type) {
+        case actionTypes.next:
+          return {
+            lastAction: action.type,
+            step: steps[steps.indexOf(state.step) + 1] ?? state.step
+          };
+
+        case actionTypes.previous:
+          return {
+            lastAction: action.type,
+            step: steps[steps.indexOf(state.step) - 1] ?? state.step
+          };
+
+        case actionTypes.goTo:
+          return {
+            lastAction: action.payload.lastAction,
+            step: steps[steps.indexOf(action.payload.step)]
+          };
+
+        default:
+          return state;
+      }
+    },
+    {
+      lastAction: 'initial',
+      step: steps[0]
+    }
+  );
+
+  const nextStep = useCallback(
+    () =>
+      dispatch({
+        payload: null,
+        type: actionTypes.next
+      }),
+    []
+  );
+
+  const previousStep = useCallback(
+    () =>
+      dispatch({
+        payload: null,
+        type: actionTypes.previous
+      }),
+    []
+  );
+
+  const goToStep = useCallback(
+    (nextStep: T) =>
+      dispatch({
+        payload: {
+          lastAction: getLastAction<T>(steps, step, nextStep),
+          step: nextStep
+        },
+        type: actionTypes.goTo
+      }),
+    [step, steps]
+  );
+
+  return {
+    goToStep,
+    isLastStep: isLastStep<T>(steps, step),
+    lastAction,
+    nextStep,
+    previousStep,
+    step,
+    stepIndex: steps.indexOf(step)
+  };
+}


### PR DESCRIPTION
This PRs adds the `use-stepper` hook. It keeps track of the state of a stepper component (current step / index / last action)
