### PR TITLE
Add `use-toggle` hook

### DIFF
--- a/packages/hooks/src/use-toggle/index.test.ts
+++ b/packages/hooks/src/use-toggle/index.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Module dependencies.
+ */
+
+import { act, renderHook } from '@testing-library/react-hooks';
+import { useToggle } from './';
+
+/**
+ * Test `useToggle` hook.
+ */
+
+describe(`'useToggle' hook`, () => {
+  it('should toggle correctly', () => {
+    const { result } = renderHook(() => {
+      const [state, toggle] = useToggle();
+
+      return { state, toggle };
+    });
+
+    expect(result.current.state).toBe(false);
+
+    act(result.current.toggle);
+    expect(result.current.state).toBe(true);
+
+    act(result.current.toggle);
+    expect(result.current.state).toBe(false);
+  });
+});

--- a/packages/hooks/src/use-toggle/index.ts
+++ b/packages/hooks/src/use-toggle/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Module dependencies.
+ */
+
+import { useCallback, useState } from 'react';
+
+/**
+ * Export `useToggle` hook.
+ */
+
+export function useToggle(initialState = false): [boolean, () => void] {
+  const [state, setState] = useState(initialState);
+  const toggle = useCallback(() => setState(state => !state), []);
+
+  return [state, toggle];
+}


### PR DESCRIPTION
This PRs adds the `use-toggle` hook. It is an abstraction for toggles
