### PR TITLE
Fix workspaces peer dependencies

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -75,8 +75,10 @@
     "yarn-deduplicate": "^5.0.0"
   },
   "peerDependencies": {
+    "@jest/types": "*",
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
+    "react-is": "*",
     "styled-components": "^5.0.0"
   },
   "engines": {

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -64,6 +64,7 @@
     "yarn-deduplicate": "^5.0.0"
   },
   "peerDependencies": {
+    "@jest/types": "*",
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
   },

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -77,8 +77,10 @@
     "yarn-deduplicate": "^5.0.0"
   },
   "peerDependencies": {
+    "@jest/types": "*",
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
+    "react-is": "*",
     "styled-components": "^5.0.0"
   },
   "engines": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -55,6 +55,9 @@
     "typescript": "^4.7.3",
     "yarn-deduplicate": "^5.0.0"
   },
+  "peerDependencies": {
+    "@jest/types": "*"
+  },
   "engines": {
     "node": ">= 14.17.0",
     "npm": "please-use-yarn",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1914,8 +1914,10 @@ __metadata:
     typescript-plugin-styled-components: ^2.0.0
     yarn-deduplicate: ^5.0.0
   peerDependencies:
+    "@jest/types": "*"
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-is: "*"
     styled-components: ^5.0.0
   languageName: unknown
   linkType: soft
@@ -1948,6 +1950,7 @@ __metadata:
     typescript: ^4.7.3
     yarn-deduplicate: ^5.0.0
   peerDependencies:
+    "@jest/types": "*"
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
   languageName: unknown
@@ -1990,8 +1993,10 @@ __metadata:
     typescript-plugin-styled-components: ^2.0.0
     yarn-deduplicate: ^5.0.0
   peerDependencies:
+    "@jest/types": "*"
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-is: "*"
     styled-components: ^5.0.0
   languageName: unknown
   linkType: soft
@@ -2015,6 +2020,8 @@ __metadata:
     ts-jest: ^28.0.4
     typescript: ^4.7.3
     yarn-deduplicate: ^5.0.0
+  peerDependencies:
+    "@jest/types": "*"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
`yarn install` was spitting out some warnings because workspace dependencies were requesting other dependencies, and the workspaces did not specify that they were met

This will result in a cleaner output