### PR TITLE
Remove dom props from Svg component

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lint-staged": "lint-staged",
     "lint:js": "eslint . --ext .js,.jsx,.ts,.tsx",
     "lint:styles": "stylelint 'src/**/*.@(ts|tsx|js)'",
-    "lint:types": "tsc --noEmit",
+    "lint:types": "tsc",
     "prepare": "husky install",
     "test": "vitest --coverage --passWithNoTests --watch false",
     "test-watch": "vitest --watch",
@@ -34,7 +34,7 @@
   },
   "lint-staged": {
     "*.@(ts|tsx)": [
-      "bash -c tsc --noEmit"
+      "bash -c tsc"
     ],
     "*.@(ts|tsx|js)": [
       "prettier --write --ignore-unknown",

--- a/src/components/svg/__snapshots__/index.test.tsx.snap
+++ b/src/components/svg/__snapshots__/index.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`'Svg' component > matches snapshot 1`] = `
 <DocumentFragment>
   <span
-    class="sc-aXZVg iUEEYG"
+    class="sc-aXZVg uhqgs"
   >
     
           

--- a/src/components/svg/index.tsx
+++ b/src/components/svg/index.tsx
@@ -2,44 +2,40 @@
  * Module dependencies.
  */
 
-import { ifProp, prop } from 'styled-tools';
-import React, { useMemo } from 'react';
-import styled, { css } from 'styled-components';
+import { prop } from 'styled-tools';
+import React, { ComponentPropsWithRef, forwardRef, useMemo } from 'react';
+import styled from 'styled-components';
 
 /**
  * Export `SvgProps` interface.
  */
 
-export interface SvgProps {
-  className?: string;
+export type SvgProps = ComponentPropsWithRef<'span'> & {
   color?: string;
-  icon: string;
-  size: string | unknown;
-}
+  icon: string | TrustedHTML;
+  size?: string;
+};
 
 /**
  * `Wrapper` styled component.
  */
 
-const Wrapper = styled.span<Omit<SvgProps, 'icon'>>`
+const Wrapper = styled.span.withConfig({
+  shouldForwardProp: prop => !['color', 'size'].includes(prop)
+})<Omit<SvgProps, 'icon'>>`
+  color: ${prop('color', 'currentColor')};
   display: inline-block;
   line-height: 0;
   position: relative;
   width: ${prop('size')};
-
-  ${ifProp(
-    'color',
-    css`
-      color: ${prop('color')};
-    `
-  )}
 `;
 
 /**
  * Export `Svg` component.
  */
 
-export function Svg({ icon, ...rest }: SvgProps) {
+export const Svg = forwardRef<HTMLSpanElement, SvgProps>((props, ref) => {
+  const { icon, ...rest } = props;
   const innerHtml = useMemo(
     () => ({
       __html: icon // eslint-disable-line id-match
@@ -47,10 +43,11 @@ export function Svg({ icon, ...rest }: SvgProps) {
     [icon]
   );
 
-  return (
-    <Wrapper
-      {...rest}
-      dangerouslySetInnerHTML={innerHtml}
-    />
-  );
-}
+  return <Wrapper {...rest} dangerouslySetInnerHTML={innerHtml} ref={ref} />;
+});
+
+/**
+ * Display name.
+ */
+
+Svg.displayName = 'Svg';

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "noEmit": false,
     "outDir": "dist",
     "rootDir": "src"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "forceConsistentCasingInFileNames": true,
     "jsx": "react",
     "lib": ["es6", "dom", "es2016", "es2017"],
+    "noEmit": true,
     "module": "esnext",
     "moduleResolution": "node",
     "paths": {


### PR DESCRIPTION
This PR removes dom props from Svg component and also updates SVGProps type.
Also fixes tsconfig to prevent emit data on pre-commit.